### PR TITLE
fix: 读取Claude Code项目目录异常 #145

### DIFF
--- a/src-tauri/src/commands/claude/project_store.rs
+++ b/src-tauri/src/commands/claude/project_store.rs
@@ -632,11 +632,7 @@ fn get_project_path_from_sessions(project_dir: &Path) -> Result<String, String> 
                 if let Ok(file) = fs::File::open(&path) {
                     let reader = BufReader::new(file);
                     // Read up to 10 lines to find cwd field
-                    for (index, line_result) in reader.lines().enumerate() {
-                        if index >= 10 {
-                            break;
-                        }
-
+                    for line_result in reader.lines().take(10) {
                         if let Ok(line) = line_result {
                             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
                                 if let Some(cwd) = json.get("cwd").and_then(|v| v.as_str()) {


### PR DESCRIPTION
从 session 文件的第一行 JSON 中读取 cwd 字段，改为扫描前十行读取 cwd 字段
<img width="443" height="164" alt="image" src="https://github.com/user-attachments/assets/8502473a-c7ae-463c-bdb0-f1365f36ea69" />
