### PR TITLE
fix(wsl): prevent Gemini from being misidentified as WSL on Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "any-code"
-version = "5.17.1"
+version = "5.18.6"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/src/commands/wsl_utils.rs
+++ b/src-tauri/src/commands/wsl_utils.rs
@@ -532,6 +532,37 @@ pub fn is_native_gemini_available() -> bool {
 fn get_native_gemini_paths() -> Vec<String> {
     let mut paths = Vec::new();
 
+    // 检测 npm 配置的自定义 prefix（nvm-windows 全局路径）
+    if let Ok(npm_prefix) = std::env::var("npm_config_prefix") {
+        paths.push(format!(r"{}\gemini.cmd", npm_prefix));
+        paths.push(format!(r"{}\gemini", npm_prefix));
+        paths.push(format!(r"{}\bin\gemini.cmd", npm_prefix));
+        paths.push(format!(r"{}\bin\gemini", npm_prefix));
+        debug!("[Gemini WSL] Checking npm_config_prefix: {}", npm_prefix);
+    }
+
+    // 检测 NVM_HOME 环境变量（nvm-windows 安装目录）
+    if let Ok(nvm_home) = std::env::var("NVM_HOME") {
+        // nvm-windows 的 node_global 目录（自定义全局路径）
+        paths.push(format!(r"{}\node_global\gemini.cmd", nvm_home));
+        paths.push(format!(r"{}\node_global\gemini", nvm_home));
+        debug!("[Gemini WSL] Checking NVM_HOME: {}", nvm_home);
+    }
+
+    // 检测 NVM_SYMLINK 环境变量（当前激活的 Node.js 版本）
+    if let Ok(nvm_symlink) = std::env::var("NVM_SYMLINK") {
+        paths.push(format!(r"{}\gemini.cmd", nvm_symlink));
+        paths.push(format!(r"{}\gemini", nvm_symlink));
+        paths.push(format!(r"{}\node_modules\.bin\gemini.cmd", nvm_symlink));
+        debug!("[Gemini WSL] Checking NVM_SYMLINK: {}", nvm_symlink);
+    }
+
+    // 常见的 nvm-windows 全局路径模式
+    if let Ok(programfiles) = std::env::var("ProgramFiles") {
+        paths.push(format!(r"{}\nvm\node_global\gemini.cmd", programfiles));
+        paths.push(format!(r"{}\nvm\node_global\gemini", programfiles));
+    }
+
     // npm 全局安装路径 (APPDATA - 标准位置)
     if let Ok(appdata) = std::env::var("APPDATA") {
         paths.push(format!(r"{}\npm\gemini.cmd", appdata));


### PR DESCRIPTION
## 闂

淇 #159 - Gemini 寮曟搸鍦?Windows 鍘熺敓鐜琚敊璇瘑鍒负 WSL 鐜锛屽鑷村璇濆け璐ャ€?

## 鍘熷洜鍒嗘瀽

get_native_gemini_paths() 鍑芥暟鐨勯瀹氫箟璺緞鍒楄〃涓湭鍖呭惈 nvm-windows 鐨勮嚜瀹氫箟鍏ㄥ眬璺緞锛堝 D:\Program Files\nvm\node_global\gemini锛夛紝瀵艰嚧 is_native_gemini_available() 妫€娴嬪け璐ワ紝GeminiMode::Auto 妯″紡涓嬮敊璇湴鍥為€€鍒?WSL 閰嶇疆妫€娴嬨€?

## 淇鏂规

鍦?src-tauri/src/commands/wsl_utils.rs 鐨?get_native_gemini_paths() 鍑芥暟涓墿灞曡矾寰勬娴嬪垪琛紝鏂板浠ヤ笅鐜鍙橀噺璺緞鏀寔锛?

- **npm_config_prefix** - npm 閰嶇疆鐨勮嚜瀹氫箟 prefix 璺緞锛坣vm-windows 鍏ㄥ眬璺緞锛?
- **NVM_HOME** - nvm-windows 瀹夎鐩綍涓嬬殑 node_global 瀛愮洰褰?
- **NVM_SYMLINK** - 褰撳墠婵€娲荤殑 Node.js 鐗堟湰璺緞
- **ProgramFiles** - 甯歌鐨?nvm-windows 鍏ㄥ眬璺緞妯″紡

## 娴嬭瘯

- 鍦?Windows 鍘熺敓鐜锛堜娇鐢?nvm-windows锛変笅楠岃瘉 Gemini 寮曟搸鍙甯告娴嬪埌
- 纭涓嶅奖鍝嶅凡鏈夌殑鏍囧噯璺緞妫€娴嬮€昏緫锛圓PPDATA銆丳rogramFiles 绛夛級